### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ var cityColumn = new DataColumn(
 // create file schema
 var schema = new Schema(idColumn.Field, cityColumn.Field);
 
-using (Stream fileStream = System.IO.File.OpenWrite("c:\\test.parquet"))
+using (Stream fileStream = System.IO.File.Create("c:\\test.parquet"))
 {
    using (var parquetWriter = new ParquetWriter(schema, fileStream))
    {


### PR DESCRIPTION
### Fixes
OpenWrite will cause corrupt parquet file, if the old file is exist and bigger than the new one. So OpenWrite is not good for example, change to use Create

### Description
OpenWrite will cause corrupt parquet file, if the old file is exist and bigger than the new one. So OpenWrite is not good for example, change to use Create

desctiption goes here

- [x] I have included unit tests validating this fix.
- [x] I have updated markdown documentation where required.
- [x] I understand that successful approval of my pull request requires reproducible tests as per [Contribution Guideline](https://github.com/aloneguid/parquet-dotnet/blob/master/.github/CONTRIBUTING.md).

<!-- Important! Once your PR is merged, CI/CD pipeline will publish a pre-release package to the following nuget feed: https://pkgs.dev.azure.com/aloneguid/AllPublic/_packaging/parquet/nuget/v3/index.json. You can then reference the pre-release package immediately from your .NET programs. Releases to nuget.org are made when pre-release packages are validated and stable. -->